### PR TITLE
feat: integrate i18n translations

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,13 +1,15 @@
 import {ProductLandingPage} from "@/modules/landing/home";
 import {getDictionary} from "@/app/[lang]/dictionaries";
+import {getProducts} from "@/modules/landing/constants/products";
 
 export default async function HomePage({params}: {
   params: Promise<{ lang: 'en' | 'tr' }>
 }) {
   const { lang } = await params
   const dict = await getDictionary(lang)
+  const products = getProducts(lang)
 
   return (
-      <ProductLandingPage dict={dict} />
+      <ProductLandingPage dict={dict} products={products} />
     );
 }

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -5,9 +5,9 @@ export default async function HomePage({params}: {
   params: Promise<{ lang: 'en' | 'tr' }>
 }) {
   const { lang } = await params
-  const dict = await getDictionary(lang) // en
+  const dict = await getDictionary(lang)
 
   return (
-      <ProductLandingPage />
+      <ProductLandingPage dict={dict} />
     );
 }

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -1,1 +1,52 @@
-{}
+{
+  "header": {
+    "home": "Home",
+    "products": "Products",
+    "categories": "Categories",
+    "about": "About"
+  },
+  "hero": {
+    "title": "Discover Amazing Products",
+    "description": "Find the perfect items for your lifestyle. From electronics to home essentials, we have everything you need at unbeatable prices.",
+    "shopNow": "Shop Now",
+    "viewCategories": "View Categories"
+  },
+  "overview": {
+    "title": "Featured Products",
+    "description": "Handpicked items that our customers love. Add them to your favorites to save for later!",
+    "ctaTitle": "Ready to Start Shopping?",
+    "ctaDescription": "Join thousands of satisfied customers and discover your new favorite products today.",
+    "ctaButton": "Browse All Products",
+    "product": {
+      "badgeNew": "New",
+      "badgeSale": "Sale",
+      "reviews": "reviews",
+      "addToCart": "Add to Cart"
+    }
+  },
+  "footer": {
+    "tagline": "Your one-stop destination for amazing products at great prices.",
+    "shop": {
+      "title": "Shop",
+      "allProducts": "All Products",
+      "electronics": "Electronics",
+      "homeGarden": "Home & Garden",
+      "fashion": "Fashion"
+    },
+    "support": {
+      "title": "Support",
+      "helpCenter": "Help Center",
+      "shippingInfo": "Shipping Info",
+      "returns": "Returns",
+      "contactUs": "Contact Us"
+    },
+    "company": {
+      "title": "Company",
+      "aboutUs": "About Us",
+      "careers": "Careers",
+      "privacyPolicy": "Privacy Policy",
+      "termsOfService": "Terms of Service"
+    },
+    "rights": "All rights reserved."
+  }
+}

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -1,5 +1,6 @@
 {
   "header": {
+    "appName": "ShopHub",
     "home": "Home",
     "products": "Products",
     "categories": "Categories",
@@ -25,6 +26,7 @@
     }
   },
   "footer": {
+    "appName": "ShopHub",
     "tagline": "Your one-stop destination for amazing products at great prices.",
     "shop": {
       "title": "Shop",

--- a/dictionaries/tr.json
+++ b/dictionaries/tr.json
@@ -1,5 +1,6 @@
 {
   "header": {
+    "appName": "MağazaHub",
     "home": "Ana Sayfa",
     "products": "Ürünler",
     "categories": "Kategoriler",
@@ -20,11 +21,12 @@
     "product": {
       "badgeNew": "Yeni",
       "badgeSale": "İndirim",
-      "reviews": "yorum",
+      "reviews": "inceleme",
       "addToCart": "Sepete Ekle"
     }
   },
   "footer": {
+    "appName": "MağazaHub",
     "tagline": "Uygun fiyatlarla harika ürünler için tek adresiniz.",
     "shop": {
       "title": "Mağaza",

--- a/dictionaries/tr.json
+++ b/dictionaries/tr.json
@@ -1,1 +1,52 @@
-{}
+{
+  "header": {
+    "home": "Ana Sayfa",
+    "products": "Ürünler",
+    "categories": "Kategoriler",
+    "about": "Hakkımızda"
+  },
+  "hero": {
+    "title": "Harika Ürünleri Keşfedin",
+    "description": "Yaşam tarzınıza uygun mükemmel ürünleri bulun. Elektronikten ev ihtiyaçlarına kadar aradığınız her şey uygun fiyatlarla burada.",
+    "shopNow": "Alışverişe Başla",
+    "viewCategories": "Kategorileri Gör"
+  },
+  "overview": {
+    "title": "Öne Çıkan Ürünler",
+    "description": "Müşterilerimizin sevdiği ürünleri sizin için seçtik. Daha sonra kaydetmek için favorilerinize ekleyin!",
+    "ctaTitle": "Alışverişe Hazır mısınız?",
+    "ctaDescription": "Binlerce mutlu müşteriye katılın ve yeni favori ürünlerinizi keşfedin.",
+    "ctaButton": "Tüm Ürünleri Gör",
+    "product": {
+      "badgeNew": "Yeni",
+      "badgeSale": "İndirim",
+      "reviews": "yorum",
+      "addToCart": "Sepete Ekle"
+    }
+  },
+  "footer": {
+    "tagline": "Uygun fiyatlarla harika ürünler için tek adresiniz.",
+    "shop": {
+      "title": "Mağaza",
+      "allProducts": "Tüm Ürünler",
+      "electronics": "Elektronik",
+      "homeGarden": "Ev & Bahçe",
+      "fashion": "Moda"
+    },
+    "support": {
+      "title": "Destek",
+      "helpCenter": "Yardım Merkezi",
+      "shippingInfo": "Kargo Bilgisi",
+      "returns": "İadeler",
+      "contactUs": "Bize Ulaşın"
+    },
+    "company": {
+      "title": "Şirket",
+      "aboutUs": "Hakkımızda",
+      "careers": "Kariyer",
+      "privacyPolicy": "Gizlilik Politikası",
+      "termsOfService": "Kullanım Şartları"
+    },
+    "rights": "Tüm hakları saklıdır."
+  }
+}

--- a/modules/landing/constants/products.ts
+++ b/modules/landing/constants/products.ts
@@ -11,7 +11,7 @@ export interface Product {
     isSale?: boolean
 }
 
-export const products: Product[] = [
+const productsEn: Product[] = [
     {
         id: 1,
         name: "Wireless Bluetooth Headphones",
@@ -72,4 +72,71 @@ export const products: Product[] = [
         reviews: 167,
         category: "Electronics",
     },
-]
+];
+
+const productsTr: Product[] = [
+    {
+        id: 1,
+        name: "Kablosuz Bluetooth Kulaklık",
+        price: 79.99,
+        originalPrice: 99.99,
+        image: "/products/airpods.jpg?height=300&width=300",
+        rating: 4.5,
+        reviews: 128,
+        category: "Elektronik",
+        isSale: true,
+    },
+    {
+        id: 2,
+        name: "Premium Kahve Makinesi",
+        price: 149.99,
+        image: "/products/coffee-maker.jpg?height=300&width=300",
+        rating: 4.8,
+        reviews: 89,
+        category: "Mutfak",
+        isNew: true,
+    },
+    {
+        id: 3,
+        name: "Ergonomik Ofis Sandalyesi",
+        price: 299.99,
+        image: "/products/chair.jpg?height=300&width=300",
+        rating: 4.6,
+        reviews: 156,
+        category: "Mobilya",
+    },
+    {
+        id: 4,
+        name: "Akıllı Fitness Saati",
+        price: 199.99,
+        originalPrice: 249.99,
+        image: "/products/watch.jpg?height=300&width=300",
+        rating: 4.4,
+        reviews: 203,
+        category: "Elektronik",
+        isSale: true,
+    },
+    {
+        id: 5,
+        name: "Organik Cilt Bakım Seti",
+        price: 89.99,
+        image: "/products/skincare-set.jpg?height=300&width=300",
+        rating: 4.7,
+        reviews: 94,
+        category: "Güzellik",
+        isNew: true,
+    },
+    {
+        id: 6,
+        name: "Taşınabilir Bluetooth Hoparlör",
+        price: 59.99,
+        image: "/products/bluetooth-speaker.jpg?height=300&width=300",
+        rating: 4.3,
+        reviews: 167,
+        category: "Elektronik",
+    },
+];
+
+export function getProducts(lang: 'en' | 'tr'): Product[] {
+    return lang === 'tr' ? productsTr : productsEn;
+}

--- a/modules/landing/detail.tsx
+++ b/modules/landing/detail.tsx
@@ -10,10 +10,16 @@ export interface ProductDetailProps {
     product: Product
     favorites: Set<number>;
     toggleFavorite: (productId: number) => void;
+    dict: {
+        badgeNew: string
+        badgeSale: string
+        reviews: string
+        addToCart: string
+    }
 }
 
 export const ProductDetail: FC<ProductDetailProps> = (props) => {
-    const {product, favorites, toggleFavorite} = props;
+    const {product, favorites, toggleFavorite, dict} = props;
 
     const renderStars = (rating: number) => {
         return Array.from({ length: 5 }, (_, i) => (
@@ -43,8 +49,8 @@ export const ProductDetail: FC<ProductDetailProps> = (props) => {
 
                 {/* Badges */}
                 <div className="absolute top-3 left-3 flex flex-col gap-2">
-                    {product.isNew && <Badge className="bg-green-500 hover:bg-green-600">New</Badge>}
-                    {product.isSale && <Badge className="bg-red-500 hover:bg-red-600">Sale</Badge>}
+                    {product.isNew && <Badge className="bg-green-500 hover:bg-green-600">{dict.badgeNew}</Badge>}
+                    {product.isSale && <Badge className="bg-red-500 hover:bg-red-600">{dict.badgeSale}</Badge>}
                 </div>
 
                 {/* Favorite Button */}
@@ -76,7 +82,7 @@ export const ProductDetail: FC<ProductDetailProps> = (props) => {
                 <div className="flex items-center gap-2 mb-3">
                     <div className="flex items-center">{renderStars(product.rating)}</div>
                     <span className="text-sm text-muted-foreground">
-                      {product.rating} ({product.reviews} reviews)
+                      {product.rating} ({product.reviews} {dict.reviews})
                     </span>
                 </div>
 
@@ -87,7 +93,7 @@ export const ProductDetail: FC<ProductDetailProps> = (props) => {
                             <span className="text-sm text-muted-foreground line-through">${product.originalPrice}</span>
                         )}
                     </div>
-                    <Button size="sm">Add to Cart</Button>
+                    <Button size="sm">{dict.addToCart}</Button>
                 </div>
             </CardContent>
         </Card>

--- a/modules/landing/footer.tsx
+++ b/modules/landing/footer.tsx
@@ -1,7 +1,36 @@
 import {ShoppingBag} from "lucide-react";
 import Link from "next/link";
+import type {FC} from "react";
 
-export const ProductLandingFooter = () => {
+interface FooterProps {
+    dict: {
+        tagline: string
+        shop: {
+            title: string
+            allProducts: string
+            electronics: string
+            homeGarden: string
+            fashion: string
+        }
+        support: {
+            title: string
+            helpCenter: string
+            shippingInfo: string
+            returns: string
+            contactUs: string
+        }
+        company: {
+            title: string
+            aboutUs: string
+            careers: string
+            privacyPolicy: string
+            termsOfService: string
+        }
+        rights: string
+    }
+}
+
+export const ProductLandingFooter: FC<FooterProps> = ({dict}) => {
     return (
         <footer className="border-t py-12 px-4">
             <div className="container mx-auto">
@@ -11,82 +40,82 @@ export const ProductLandingFooter = () => {
                             <ShoppingBag className="h-6 w-6" />
                             <span className="font-bold text-xl">ShopHub</span>
                         </div>
-                        <p className="text-muted-foreground">Your one-stop destination for amazing products at great prices.</p>
+                        <p className="text-muted-foreground">{dict.tagline}</p>
                     </div>
 
                     <div>
-                        <h3 className="font-semibold mb-4">Shop</h3>
+                        <h3 className="font-semibold mb-4">{dict.shop.title}</h3>
                         <ul className="space-y-2 text-muted-foreground">
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    All Products
+                                    {dict.shop.allProducts}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Electronics
+                                    {dict.shop.electronics}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Home & Garden
+                                    {dict.shop.homeGarden}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Fashion
+                                    {dict.shop.fashion}
                                 </Link>
                             </li>
                         </ul>
                     </div>
 
                     <div>
-                        <h3 className="font-semibold mb-4">Support</h3>
+                        <h3 className="font-semibold mb-4">{dict.support.title}</h3>
                         <ul className="space-y-2 text-muted-foreground">
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Help Center
+                                    {dict.support.helpCenter}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Shipping Info
+                                    {dict.support.shippingInfo}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Returns
+                                    {dict.support.returns}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Contact Us
+                                    {dict.support.contactUs}
                                 </Link>
                             </li>
                         </ul>
                     </div>
 
                     <div>
-                        <h3 className="font-semibold mb-4">Company</h3>
+                        <h3 className="font-semibold mb-4">{dict.company.title}</h3>
                         <ul className="space-y-2 text-muted-foreground">
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    About Us
+                                    {dict.company.aboutUs}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Careers
+                                    {dict.company.careers}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Privacy Policy
+                                    {dict.company.privacyPolicy}
                                 </Link>
                             </li>
                             <li>
                                 <Link href="#" className="hover:text-foreground transition-colors">
-                                    Terms of Service
+                                    {dict.company.termsOfService}
                                 </Link>
                             </li>
                         </ul>
@@ -94,7 +123,7 @@ export const ProductLandingFooter = () => {
                 </div>
 
                 <div className="border-t mt-8 pt-8 text-center text-muted-foreground">
-                    <p>&copy; {new Date().getFullYear()} ShopHub. All rights reserved.</p>
+                    <p>&copy; {new Date().getFullYear()} ShopHub. {dict.rights}</p>
                 </div>
             </div>
         </footer>

--- a/modules/landing/footer.tsx
+++ b/modules/landing/footer.tsx
@@ -4,6 +4,7 @@ import type {FC} from "react";
 
 interface FooterProps {
     dict: {
+        appName: string
         tagline: string
         shop: {
             title: string
@@ -38,7 +39,7 @@ export const ProductLandingFooter: FC<FooterProps> = ({dict}) => {
                     <div>
                         <div className="flex items-center space-x-2 mb-4">
                             <ShoppingBag className="h-6 w-6" />
-                            <span className="font-bold text-xl">ShopHub</span>
+                            <span className="font-bold text-xl">{dict.appName}</span>
                         </div>
                         <p className="text-muted-foreground">{dict.tagline}</p>
                     </div>
@@ -123,7 +124,7 @@ export const ProductLandingFooter: FC<FooterProps> = ({dict}) => {
                 </div>
 
                 <div className="border-t mt-8 pt-8 text-center text-muted-foreground">
-                    <p>&copy; {new Date().getFullYear()} ShopHub. {dict.rights}</p>
+                    <p>&copy; {new Date().getFullYear()} {dict.appName}. {dict.rights}</p>
                 </div>
             </div>
         </footer>

--- a/modules/landing/header.tsx
+++ b/modules/landing/header.tsx
@@ -8,6 +8,7 @@ import {ModeToggle} from "@/components/mode-toggle";
 export interface HeaderProps {
     favorites: Set<number>;
     dict: {
+        appName: string
         home: string
         products: string
         categories: string
@@ -24,7 +25,7 @@ export const ProductLandingHeader: FC<HeaderProps> = (props) => {
                 <div className="flex items-center space-x-4">
                     <Link href="/" className="flex items-center space-x-2">
                         <ShoppingBag className="h-6 w-6" />
-                        <span className="font-bold text-xl">ShopHub</span>
+                        <span className="font-bold text-xl">{dict.appName}</span>
                     </Link>
                 </div>
 

--- a/modules/landing/header.tsx
+++ b/modules/landing/header.tsx
@@ -7,10 +7,16 @@ import {ModeToggle} from "@/components/mode-toggle";
 
 export interface HeaderProps {
     favorites: Set<number>;
+    dict: {
+        home: string
+        products: string
+        categories: string
+        about: string
+    }
 }
 
 export const ProductLandingHeader: FC<HeaderProps> = (props) => {
-    const {favorites} = props;
+    const {favorites, dict} = props;
 
     return (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -24,16 +30,16 @@ export const ProductLandingHeader: FC<HeaderProps> = (props) => {
 
                 <nav className="hidden md:flex items-center space-x-6">
                     <Link href="#" className="text-sm font-medium hover:text-primary transition-colors">
-                        Home
+                        {dict.home}
                     </Link>
                     <Link href="#" className="text-sm font-medium hover:text-primary transition-colors">
-                        Products
+                        {dict.products}
                     </Link>
                     <Link href="#" className="text-sm font-medium hover:text-primary transition-colors">
-                        Categories
+                        {dict.categories}
                     </Link>
                     <Link href="#" className="text-sm font-medium hover:text-primary transition-colors">
-                        About
+                        {dict.about}
                     </Link>
                 </nav>
 

--- a/modules/landing/hero.tsx
+++ b/modules/landing/hero.tsx
@@ -1,20 +1,29 @@
 import {Button} from "@/components/ui/button";
+import type {FC} from "react";
 
-export const ProductLandingHero = () => {
+interface HeroProps {
+    dict: {
+        title: string
+        description: string
+        shopNow: string
+        viewCategories: string
+    }
+}
+
+export const ProductLandingHero: FC<HeroProps> = ({dict}) => {
     return (
         <section className="relative py-20 px-4 text-center bg-gradient-to-br from-primary/10 via-background to-secondary/10">
             <div className="container mx-auto max-w-4xl">
-                <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">Discover Amazing Products</h1>
+                <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">{dict.title}</h1>
                 <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-                    Find the perfect items for your lifestyle. From electronics to home essentials, we have everything you need
-                    at unbeatable prices.
+                    {dict.description}
                 </p>
                 <div className="flex flex-col sm:flex-row gap-4 justify-center">
                     <Button size="lg" className="text-lg px-8">
-                        Shop Now
+                        {dict.shopNow}
                     </Button>
                     <Button variant="outline" size="lg" className="text-lg px-8 bg-transparent">
-                        View Categories
+                        {dict.viewCategories}
                     </Button>
                 </div>
             </div>

--- a/modules/landing/home.tsx
+++ b/modules/landing/home.tsx
@@ -1,12 +1,21 @@
 "use client"
 
-import { useState } from "react"
+import {useState, FC} from "react"
 import {ProductLandingHeader} from "@/modules/landing/header";
 import {ProductLandingHero} from "@/modules/landing/hero";
 import {ProductLandingFooter} from "@/modules/landing/footer";
 import {ProductOverview} from "@/modules/landing/overview";
 
-export const ProductLandingPage = () => {
+export interface ProductLandingPageProps {
+    dict: {
+        header: any
+        hero: any
+        overview: any
+        footer: any
+    }
+}
+
+export const ProductLandingPage: FC<ProductLandingPageProps> = ({dict}) => {
     const [favorites, setFavorites] = useState<Set<number>>(new Set())
 
     const toggleFavorite = (productId: number) => {
@@ -24,16 +33,16 @@ export const ProductLandingPage = () => {
     return (
         <div className="min-h-screen bg-background">
             {/* Header */}
-            <ProductLandingHeader favorites={favorites} />
+            <ProductLandingHeader favorites={favorites} dict={dict.header} />
 
             {/* Hero Section */}
-            <ProductLandingHero />
+            <ProductLandingHero dict={dict.hero} />
 
             {/* Products Section */}
-            <ProductOverview favorites={favorites} toggleFavorite={toggleFavorite} />
+            <ProductOverview favorites={favorites} toggleFavorite={toggleFavorite} dict={dict.overview} />
 
             {/* Footer */}
-            <ProductLandingFooter />
+            <ProductLandingFooter dict={dict.footer} />
         </div>
     )
 }

--- a/modules/landing/home.tsx
+++ b/modules/landing/home.tsx
@@ -5,6 +5,7 @@ import {ProductLandingHeader} from "@/modules/landing/header";
 import {ProductLandingHero} from "@/modules/landing/hero";
 import {ProductLandingFooter} from "@/modules/landing/footer";
 import {ProductOverview} from "@/modules/landing/overview";
+import type {Product} from "@/modules/landing/constants/products";
 
 export interface ProductLandingPageProps {
     dict: {
@@ -13,9 +14,10 @@ export interface ProductLandingPageProps {
         overview: any
         footer: any
     }
+    products: Product[]
 }
 
-export const ProductLandingPage: FC<ProductLandingPageProps> = ({dict}) => {
+export const ProductLandingPage: FC<ProductLandingPageProps> = ({dict, products}) => {
     const [favorites, setFavorites] = useState<Set<number>>(new Set())
 
     const toggleFavorite = (productId: number) => {
@@ -39,7 +41,7 @@ export const ProductLandingPage: FC<ProductLandingPageProps> = ({dict}) => {
             <ProductLandingHero dict={dict.hero} />
 
             {/* Products Section */}
-            <ProductOverview favorites={favorites} toggleFavorite={toggleFavorite} dict={dict.overview} />
+            <ProductOverview favorites={favorites} toggleFavorite={toggleFavorite} products={products} dict={dict.overview} />
 
             {/* Footer */}
             <ProductLandingFooter dict={dict.footer} />

--- a/modules/landing/overview.tsx
+++ b/modules/landing/overview.tsx
@@ -4,25 +4,34 @@ import type {FC} from "react";
 import {ProductDetail} from "@/modules/landing/detail";
 import type { ProductDetailProps } from "@/modules/landing/detail";
 
-export interface ProductOverviewProps extends Pick<ProductDetailProps, 'favorites' | 'toggleFavorite'> {}
+export interface ProductOverviewProps extends Pick<ProductDetailProps, 'favorites' | 'toggleFavorite'> {
+    dict: {
+        title: string
+        description: string
+        ctaTitle: string
+        ctaDescription: string
+        ctaButton: string
+        product: ProductDetailProps['dict']
+    }
+}
 
 export const ProductOverview: FC<ProductOverviewProps> = (props) => {
-    const {favorites, toggleFavorite} = props;
+    const {favorites, toggleFavorite, dict} = props;
 
     return (
         <>
             <section className="py-16 px-4">
                 <div className="container mx-auto">
                     <div className="text-center mb-12">
-                        <h2 className="text-3xl md:text-4xl font-bold mb-4">Featured Products</h2>
+                        <h2 className="text-3xl md:text-4xl font-bold mb-4">{dict.title}</h2>
                         <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-                            Handpicked items that our customers love. Add them to your favorites to save for later!
+                            {dict.description}
                         </p>
                     </div>
 
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                         {products.map((product) => (
-                            <ProductDetail key={product.id} product={product} favorites={favorites} toggleFavorite={toggleFavorite} />
+                            <ProductDetail key={product.id} product={product} favorites={favorites} toggleFavorite={toggleFavorite} dict={dict.product} />
                         ))}
                     </div>
                 </div>
@@ -31,12 +40,12 @@ export const ProductOverview: FC<ProductOverviewProps> = (props) => {
             {/* CTA Section */}
             <section className="py-16 px-4 bg-muted">
                 <div className="container mx-auto text-center">
-                    <h2 className="text-3xl font-bold mb-4">Ready to Start Shopping?</h2>
+                    <h2 className="text-3xl font-bold mb-4">{dict.ctaTitle}</h2>
                     <p className="text-muted-foreground text-lg mb-8 max-w-2xl mx-auto">
-                        Join thousands of satisfied customers and discover your new favorite products today.
+                        {dict.ctaDescription}
                     </p>
                     <Button size="lg" className="text-lg px-8">
-                        Browse All Products
+                        {dict.ctaButton}
                     </Button>
                 </div>
             </section>

--- a/modules/landing/overview.tsx
+++ b/modules/landing/overview.tsx
@@ -1,10 +1,11 @@
 import {Button} from "@/components/ui/button";
-import {products} from "@/modules/landing/constants/products";
 import type {FC} from "react";
 import {ProductDetail} from "@/modules/landing/detail";
 import type { ProductDetailProps } from "@/modules/landing/detail";
+import type { Product } from "@/modules/landing/constants/products";
 
 export interface ProductOverviewProps extends Pick<ProductDetailProps, 'favorites' | 'toggleFavorite'> {
+    products: Product[]
     dict: {
         title: string
         description: string
@@ -16,7 +17,7 @@ export interface ProductOverviewProps extends Pick<ProductDetailProps, 'favorite
 }
 
 export const ProductOverview: FC<ProductOverviewProps> = (props) => {
-    const {favorites, toggleFavorite, dict} = props;
+    const {favorites, toggleFavorite, products, dict} = props;
 
     return (
         <>


### PR DESCRIPTION
## Summary
- add English and Turkish translation dictionaries for header, hero, product sections, and footer
- wire dictionaries into page loading and pass locale data through component tree
- render navigation, hero text, product info, and footer content from selected locale

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688f14e3235c832cadd6fb28e8eaa5fe